### PR TITLE
Fixed Alembic migrations folder not persisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 web/app/node_modules/
 ldap-data/
 logs/
+migrations/
 
 api/database.mwb.bak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - "5000:5000"
     volumes:
       - ./api/app:/app
+      - ./migrations:/migrations
       - ./logs:/logs
     environment: 
       FLASK_API_VERSION: "1.0"


### PR DESCRIPTION
Alembic migrations folder was in the container under `/migrations`

We now mount this folder as a volume to persist it.